### PR TITLE
Drop required_ruby_version to 2.0

### DIFF
--- a/cocoapods-amicable.gemspec
+++ b/cocoapods-amicable.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 12.3'
 
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '~> 2.0'
 end


### PR DESCRIPTION
This seems to work fine without any other changes. Sierra's `/usr/bin/ruby` is 2.0.0-p648 so it's nice to support this.