### PR TITLE
Add support for Ruby 3.x

### DIFF
--- a/cocoapods-amicable.gemspec
+++ b/cocoapods-amicable.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'rake', '~> 12.3'
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
When targeting Ruby 3.x in a project `cocoapods-amicable` resolves to version `0.1.0` instead of the latest version, as that was the last version of the plugin that didn't declare an explicit version of Ruby in the Gemspec.

There doesn't appear to be any breaking changes in Ruby 3.x that affect this plugin when executing `pod install` so it is safe to assume that it can support all Ruby versions >= 2.0.